### PR TITLE
Add team statement received notification

### DIFF
--- a/app/schemas/NotificationsSchema.py
+++ b/app/schemas/NotificationsSchema.py
@@ -1,5 +1,6 @@
-from typing import TypeVar
+from typing import TypeVar, Optional, List
 from enum import Enum
+
 
 from app.schemas.BaseScheme import BaseScheme
 
@@ -13,6 +14,7 @@ class NotificationTypeEnum(Enum):
     LOW_BALANCE = 'LOW_BALANCE'
     ENABLE_REQ_FOR_FILL = 'ENABLE_REQ_FOR_FILL'
     DISABLE_REQ_FOR_FILL = 'DISABLE_REQ_FOR_FILL'
+    TEAM_STATEMENT_RECEIVED = 'TEAM_STATEMENT_RECEIVED'
 
 
 class AbstractNotificationSchema(BaseScheme):
@@ -87,11 +89,13 @@ class DisableReqForFillSupportNotificationSchema(BaseSupportNotificationSchema):
     data: ReqDisabledNotificationDataSchema
 
 
-class TeamStatementReceivedSchema(BaseModel):
+class TeamStatementReceivedSchema(BaseSupportNotificationSchema):
     """Уходит сапорту, когда команда загрузила выписку по отклонённой апелляции."""
+
+    event_type: str = NotificationTypeEnum.TEAM_STATEMENT_RECEIVED
     appeal_id: str
     transaction_id: str
     merchant_transaction_id: Optional[str] = None
     merchant_appeal_id: Optional[str] = None
     reject_reason: Optional[str] = None      # чтобы сапорт видел, почему отклоняли
-    file_ids: List[str]  
+    file_ids: List[str]

--- a/docs/team_statement_received_alert.md
+++ b/docs/team_statement_received_alert.md
@@ -1,0 +1,13 @@
+The **TEAM_STATEMENT_RECEIVED** alert notifies support when a team uploads a bank statement after an appeal has been declined.
+
+It is triggered by the `upload_team_statement` endpoint once the statement is successfully saved and the appeal contains a `reject_reason`.
+
+The notification payload includes:
+- `appeal_id`
+- `transaction_id`
+- `merchant_transaction_id`
+- `merchant_appeal_id`
+- `reject_reason`
+- `file_ids` – identifiers of the uploaded files
+
+Support receives this alert so they can review the new documents and close out the declined appeal if necessary.


### PR DESCRIPTION
## Summary
- notify support when a team uploads statement after appeal rejection
- add `TEAM_STATEMENT_RECEIVED` notification type
- trigger alert from `upload_team_statement`
- document the new alert

## Testing
- `python -m py_compile app/functions/appeal.py app/schemas/NotificationsSchema.py`

------
https://chatgpt.com/codex/tasks/task_e_687a92d1a55c83228a9763e79ef846c7