### PR TITLE
Add support confirmation notification

### DIFF
--- a/app/schemas/NotificationsSchema.py
+++ b/app/schemas/NotificationsSchema.py
@@ -13,6 +13,7 @@ class NotificationTypeEnum(Enum):
     LOW_BALANCE = 'LOW_BALANCE'
     ENABLE_REQ_FOR_FILL = 'ENABLE_REQ_FOR_FILL'
     DISABLE_REQ_FOR_FILL = 'DISABLE_REQ_FOR_FILL'
+    APPEAL_SUPPORT_CONFIRMATION_REQUIRED = 'APPEAL_SUPPORT_CONFIRMATION_REQUIRED'
 
 
 class AbstractNotificationSchema(BaseScheme):
@@ -85,6 +86,18 @@ class DisableReqForFillSupportNotificationSchema(BaseSupportNotificationSchema):
     event_type: str = NotificationTypeEnum.DISABLE_REQ_FOR_FILL
 
     data: ReqDisabledNotificationDataSchema
+
+
+class SupportConfirmationRequiredDataSchema(BaseScheme):
+    appeal_id: str
+    transaction_id: str
+    link: str
+
+
+class SupportConfirmationRequiredSchema(BaseSupportNotificationSchema):
+    event_type: str = NotificationTypeEnum.APPEAL_SUPPORT_CONFIRMATION_REQUIRED
+
+    data: SupportConfirmationRequiredDataSchema
 
 
 class TeamStatementReceivedSchema(BaseModel):


### PR DESCRIPTION
## Summary
- extend `NotificationTypeEnum` with appeal support confirmation notification
- add `SupportConfirmationRequiredSchema`
- notify support when appeal requires confirmation
- avoid duplicate notifications

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anyio')*

------
https://chatgpt.com/codex/tasks/task_e_687a92d1ba24832291df1b03b71bbedd