### PR TITLE
Add timeout expired alert for appeals

### DIFF
--- a/app/functions/appeal.py
+++ b/app/functions/appeal.py
@@ -63,7 +63,12 @@ from app.functions.external_transaction import external_transaction_update_
 from app.functions.merchant_callback import send_callback
 from app.utils.time import calculate_end_time_with_pause
 from app.services import notification_service
-from app.schemas.NotificationsSchema import NewAppealNotificationSchema, NewAppealNotificationDataSchema
+from app.schemas.NotificationsSchema import (
+    NewAppealNotificationSchema,
+    NewAppealNotificationDataSchema,
+    TimeoutExpiredNotificationSchema,
+    TimeoutExpiredNotificationDataSchema,
+)
 from app.core.config import settings
 
 
@@ -1144,6 +1149,16 @@ async def accept_appeal_by_system(session: AsyncSession, appeal_id: str):
         raise AppealNotFoundException()
 
     appeal.timeout_expired = True
+
+    await notification_service.send_notification(
+        TimeoutExpiredNotificationSchema(
+            support_id="all",
+            data=TimeoutExpiredNotificationDataSchema(
+                appeal_id=appeal.id,
+                transaction_id=appeal.transaction_id,
+            ),
+        )
+    )
 
     await session.commit()
 

--- a/app/schemas/NotificationsSchema.py
+++ b/app/schemas/NotificationsSchema.py
@@ -1,6 +1,7 @@
-from typing import TypeVar
+from typing import TypeVar, List, Optional
 from enum import Enum
 
+from pydantic import BaseModel
 from app.schemas.BaseScheme import BaseScheme
 
 
@@ -13,6 +14,7 @@ class NotificationTypeEnum(Enum):
     LOW_BALANCE = 'LOW_BALANCE'
     ENABLE_REQ_FOR_FILL = 'ENABLE_REQ_FOR_FILL'
     DISABLE_REQ_FOR_FILL = 'DISABLE_REQ_FOR_FILL'
+    APPEAL_TIMEOUT_EXPIRED = 'APPEAL_TIMEOUT_EXPIRED'
 
 
 class AbstractNotificationSchema(BaseScheme):
@@ -85,6 +87,17 @@ class DisableReqForFillSupportNotificationSchema(BaseSupportNotificationSchema):
     event_type: str = NotificationTypeEnum.DISABLE_REQ_FOR_FILL
 
     data: ReqDisabledNotificationDataSchema
+
+
+class TimeoutExpiredNotificationDataSchema(BaseScheme):
+    appeal_id: str
+    transaction_id: str
+
+
+class TimeoutExpiredNotificationSchema(BaseSupportNotificationSchema):
+    event_type: str = NotificationTypeEnum.APPEAL_TIMEOUT_EXPIRED
+
+    data: TimeoutExpiredNotificationDataSchema
 
 
 class TeamStatementReceivedSchema(BaseModel):

--- a/docs/notification_types.md
+++ b/docs/notification_types.md
@@ -1,0 +1,3 @@
+# Notification types
+
+- `APPEAL_TIMEOUT_EXPIRED` - notification sent to all support accounts when an appeal is automatically accepted because its waiting period expired.


### PR DESCRIPTION
## Summary
- support `APPEAL_TIMEOUT_EXPIRED` alert type
- notify support when the system auto-accepts an appeal
- document available notification type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anyio')*

------
https://chatgpt.com/codex/tasks/task_e_687a92d0de98832293441a6dae51cebf